### PR TITLE
Add auto-generated types for icon names

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,10 +1,14 @@
 import { Button, Text, View } from "react-native";
 
-import { getAppIcon, setAppIcon } from "expo-dynamic-app-icon";
+import {
+  getAppIcon,
+  IconName,
+  setAppIcon,
+} from "@mozzius/expo-dynamic-app-icon";
 import { useState } from "react";
 
 export default function App() {
-  const [iconName, setIconName] = useState<string>();
+  const [iconName, setIconName] = useState<IconName | "DEFAULT">();
 
   return (
     <View

--- a/example/app.json
+++ b/example/app.json
@@ -31,7 +31,7 @@
     },
     "plugins": [
       [
-        "../app.plugin",
+        "@mozzius/expo-dynamic-app-icon",
         {
           "light": {
             "ios": "./assets/ios_icon_default_light.png",

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.74.1",
-    "react-native-web": "~0.19.11"
+    "react-native-web": "~0.19.11",
+    "@mozzius/expo-dynamic-app-icon": "link:./../"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
@@ -24,10 +25,5 @@
     "@types/react-native": "~0.73.0",
     "typescript": "^5.6.3"
   },
-  "private": true,
-  "expo": {
-    "autolinking": {
-      "nativeModulesDir": ".."
-    }
-  }
+  "private": true
 }

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true,
-    "paths": {
-      "expo-dynamic-app-icon": ["../src/index"],
-      "expo-dynamic-app-icon/*": ["../src/*"]
-    }
+    "strict": true
   }
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1053,6 +1053,23 @@
     dotenv-expand "~11.0.6"
     getenv "^1.0.0"
 
+"@expo/image-utils@^0.3.23":
+  version "0.3.23"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.23.tgz#f14fd7e1f5ff6f8e4911a41e27dd274470665c3f"
+  integrity sha512-nhUVvW0TrRE4jtWzHQl8TR4ox7kcmrc2I0itaeJGjxF5A54uk7avgA0wRt7jP1rdvqQo1Ke1lXyLYREdhN9tPw==
+  dependencies:
+    "@expo/spawn-async" "1.5.0"
+    chalk "^4.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    jimp-compact "0.16.1"
+    mime "^2.4.4"
+    node-fetch "^2.6.0"
+    parse-png "^2.1.0"
+    resolve-from "^5.0.0"
+    semver "7.3.2"
+    tempy "0.3.0"
+
 "@expo/image-utils@^0.5.0":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.5.1.tgz#06fade141facebcd8431355923d30f3839309942"
@@ -1180,6 +1197,13 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
   integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==
+
+"@expo/spawn-async@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.5.0.tgz#799827edd8c10ef07eb1a2ff9dcfe081d596a395"
+  integrity sha512-LB7jWkqrHo+5fJHNrLAFdimuSXQ2MQ4lA7SQW5bf/HbsXuV2VrT/jN/M8f/KoWt0uJMGN4k/j7Opx4AvOOxSew==
+  dependencies:
+    cross-spawn "^6.0.5"
 
 "@expo/spawn-async@^1.7.2":
   version "1.7.2"
@@ -1383,6 +1407,10 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@mozzius/expo-dynamic-app-icon@link:./..":
+  version "0.0.0"
+  uid ""
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3028,7 +3056,7 @@ cross-fetch@^3.1.5:
   dependencies:
     node-fetch "^2.6.12"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.6.tgz#30d0efa0712ddb7eb5a76e1e8721bffafa6b5d57"
   integrity sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==
@@ -3532,7 +3560,7 @@ expo-modules-autolinking@1.11.3:
     require-from-string "^2.0.2"
     resolve-from "^5.0.0"
 
-expo-modules-core@1.12.26:
+expo-modules-core@1.12.26, expo-modules-core@^1.0.3:
   version "1.12.26"
   resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.12.26.tgz#86c4087dc6246abfc4d7f5e61097dc8cc4b22262"
   integrity sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==
@@ -5404,7 +5432,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.4.1:
+mime@^2.4.1, mime@^2.4.4:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
@@ -6542,6 +6570,11 @@ selfsigned@^2.4.1:
   dependencies:
     "@types/node-forge" "^1.3.0"
     node-forge "^1"
+
+semver@7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 semver@^5.5.0, semver@^5.6.0:
   version "5.7.2"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Programmatically change the app icon in Expo.",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "files": [
+    "build"
+  ],
   "scripts": {
     "build": "expo-module build",
     "build:plugin": "tsc --build ./plugin",

--- a/plugin/src/withDynamicIcon.ts
+++ b/plugin/src/withDynamicIcon.ts
@@ -100,10 +100,7 @@ function withGenerateTypes(config: ExpoConfig, props: { icons: IconSet }) {
 
   const buildFile = path.join(moduleRoot, "build", "types.d.ts");
   const buildFileContent = fs.readFileSync(buildFile, "utf8");
-  const updatedContent = buildFileContent.replace(
-    "IconName: string",
-    unionType
-  );
+  const updatedContent = buildFileContent.replace(/IconName:\s.*/, unionType);
   fs.writeFileSync(buildFile, updatedContent);
 
   return config;

--- a/plugin/src/withDynamicIcon.ts
+++ b/plugin/src/withDynamicIcon.ts
@@ -7,12 +7,15 @@ import {
   withXcodeProject,
   withAndroidManifest,
   AndroidConfig,
+  ExportedConfigWithProps,
 } from "@expo/config-plugins";
 import { generateImageAsync } from "@expo/image-utils";
 import fs from "fs";
 import path from "path";
 // @ts-ignore - no types
 import pbxFile from "xcode/lib/pbxFile";
+
+const moduleRoot = path.join(__dirname, "..", "..");
 
 const { getMainApplicationOrThrow, getMainActivityOrThrow } =
   AndroidConfig.Manifest;
@@ -71,6 +74,8 @@ const withDynamicIcon: ConfigPlugin<string[] | IconSet | void> = (
   const icons = resolveIcons(props);
   const dimensions = resolveIconDimensions(config);
 
+  config = withGenerateTypes(config, { icons });
+
   // for ios
   config = withIconXcodeProject(config, { icons, dimensions });
   config = withIconInfoPlist(config, { icons, dimensions });
@@ -82,6 +87,27 @@ const withDynamicIcon: ConfigPlugin<string[] | IconSet | void> = (
 
   return config;
 };
+
+// =============================================================================
+//                                   TypeScript
+// =============================================================================
+
+function withGenerateTypes(config: ExpoConfig, props: { icons: IconSet }) {
+  const names = Object.keys(props.icons);
+  const union = names.map((name) => `"${name}"`).join(" | ") || "string";
+
+  const unionType = `IconName: ${union}`;
+
+  const buildFile = path.join(moduleRoot, "build", "types.d.ts");
+  const buildFileContent = fs.readFileSync(buildFile, "utf8");
+  const updatedContent = buildFileContent.replace(
+    "IconName: string",
+    unionType
+  );
+  fs.writeFileSync(buildFile, updatedContent);
+
+  return config;
+}
 
 // =============================================================================
 //                                    Android

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,14 @@
 import ExpoDynamicAppIconModule from "./ExpoDynamicAppIconModule";
+import { DynamicAppIconRegistry } from "./types";
 
-export function setAppIcon(name: string | null): string | false {
+export type IconName = DynamicAppIconRegistry["IconName"];
+
+export function setAppIcon(
+  name: IconName | null
+): IconName | "DEFAULT" | false {
   return ExpoDynamicAppIconModule.setAppIcon(name);
 }
 
-export function getAppIcon(): string {
+export function getAppIcon(): IconName | "DEFAULT" {
   return ExpoDynamicAppIconModule.getAppIcon();
 }

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -1,7 +1,13 @@
-export function setAppIcon(name: string | null): string | false {
+import { DynamicAppIconRegistry } from "./types";
+
+export type IconName = DynamicAppIconRegistry["IconName"];
+
+export function setAppIcon(
+  name: IconName | null
+): IconName | "DEFAULT" | false {
   throw new Error("setAppIcon is not supported on web");
 }
 
-export function getAppIcon(): string {
+export function getAppIcon(): IconName | "DEFAULT" {
   throw new Error("getAppIcon is not supported on web");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export interface DynamicAppIconRegistry {
+  IconName: string;
+}


### PR DESCRIPTION
## Motivation

<img width="400" alt="Screenshot 2024-11-29 at 12 44 01 PM" src="https://github.com/user-attachments/assets/b30c2c15-346e-49a3-a0ab-2ae10d444c8c">

Since we already know ahead of time what the icon names will be, let's make our getters and setters strongly typed!

## What This Does

- Adds a new `DynamicAppIconRegistry` interface for defining the `IconName` type
- Adds a new custom mod in our Expo plugin to generate the union `IconName` based on our config plugin
- Updates `example` set up to use Yarn local linking for a closer-to-prod setup

## How it Works

1. User defines the different icons in their Expo `app.json` config
2. When the development server starts, the `withGenerateTypes` plugin mod runs
3. The `types.d.ts` file in the module `build` directory is updated with the strict types
4. The user can now access those types with the `IconName` import from `@mozzius/expo-dynamic-app-icon`

## How to Test

1. Rebuild the plugin (`yarn build:plugin`) and module (`yarn build`)
5. Start the development server (`yarn start`)
6. Try to change the set call in `App.tsx` L37. Confirm it's now strictly typed!

## TODO

- [ ] Re-generate the types automatically when `app.json` changes (instead of needing to restart the dev server)