### PR TITLE
Fix round icons on android

### DIFF
--- a/plugin/src/withDynamicIcon.ts
+++ b/plugin/src/withDynamicIcon.ts
@@ -232,8 +232,7 @@ const withIconAndroidImages: ConfigPlugin<Props> = (config, { icons }) => {
               {
                 name: fileName,
                 src: android,
-                removeTransparency: true,
-                backgroundColor: "#ffffff",
+                removeTransparency: false,
                 resizeMode: "cover",
                 width: size,
                 height: size,


### PR DESCRIPTION
They need a transparent background to work properly