### PR TITLE
Improve Android behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,19 @@ check added line
 
 ```xml
   ...
-    <activity-alias android:name="expo.modules.dynamicappicon.example.MainActivityred" android:enabled="false" android:exported="true" android:icon="@mipmap/red" android:targetActivity=".MainActivity">
+    <activity-alias android:name="expo.modules.dynamicappicon.example.MainActivitylight" android:enabled="false" android:exported="true" android:icon="@mipmap/light" android:targetActivity=".MainActivity" android:roundIcon="@mipmap/light_round">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity-alias>
-    <activity-alias android:name="expo.modules.dynamicappicon.example.MainActivitygray" android:enabled="false" android:exported="true" android:icon="@mipmap/gray" android:targetActivity=".MainActivity">
+    <activity-alias android:name="expo.modules.dynamicappicon.example.MainActivitydark" android:enabled="false" android:exported="true" android:icon="@mipmap/dark" android:targetActivity=".MainActivity" android:roundIcon="@mipmap/dark_round">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity-alias>
+  </application>
   ...
 ```
 
@@ -73,6 +74,8 @@ create a new `expo-dev-client` and begin using `expo-dynamic-app-icon`
 - if error, return **false**
 - else, return **changed app icon name**
 - pass `null` to reset app icon to default
+
+> Note: this causes the app to close on Android, and a popup to appear on iOS
 
 ```typescript
 import { setAppIcon } from "expo-dynamic-app-icon";

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Programmatically change the app icon in Expo.
 npx expo install @mozzius/expo-dynamic-app-icon
 ```
 
-## Set icon file
+### Set icon file
 
 add plugins in `app.json`
 
@@ -38,14 +38,9 @@ add plugins in `app.json`
     ]
 ```
 
-## Check AndroidManifest (for android)
+#### Optional: check AndroidManifest (for android)
 
-```
-expo prebuild
-```
-
-check added line
-[AndroidManifest.xml](./example/android/app/src/main/AndroidManifest.xml#L33-L44)
+After running `expo prebuild`, check the modifications to your `AndroidManifest.xml`. Additional `activity-alias` are added for each icon.
 
 ```xml
   ...
@@ -65,11 +60,11 @@ check added line
   ...
 ```
 
-## Create new `expo-dev-client`
+### Create new `expo-dev-client`
 
-create a new `expo-dev-client` and begin using `expo-dynamic-app-icon`
+Create a new `expo-dev-client` and begin using `expo-dynamic-app-icon`!
 
-## Use `setAppIcon`
+### Use `setAppIcon`
 
 - if error, return **false**
 - else, return **changed app icon name**
@@ -85,7 +80,7 @@ import { setAppIcon } from "expo-dynamic-app-icon";
 setAppIcon("red") // set icon 'assets/icon1.png'
 ```
 
-## Use `getAppIcon`
+### Use `getAppIcon`
 
 get current app icon name
 

--- a/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconModule.kt
+++ b/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconModule.kt
@@ -15,6 +15,8 @@ class ExpoDynamicAppIconModule : Module() {
                 SharedObject.pm = pm
                 SharedObject.shouldChangeIcon = true
 
+                var result: String
+
                 if (name == null) {
                     // Resetting to default icon if nothing passed
                     var currentIcon =
@@ -23,12 +25,10 @@ class ExpoDynamicAppIconModule : Module() {
 
                     SharedObject.classesToKill.add(currentIcon)
                     SharedObject.icon = context.packageName + ".MainActivity"
-
-                    return@Function "DEFAULT"
+                    result = "DEFAULT"
                 } else {
-
-                    var newIcon: String = context.packageName + ".MainActivity" + name
-                    var currentIcon: String =
+                    var newIcon = context.packageName + ".MainActivity" + name
+                    var currentIcon =
                             if (!SharedObject.icon.isEmpty()) SharedObject.icon
                             else context.packageName + ".MainActivity"
 
@@ -38,9 +38,17 @@ class ExpoDynamicAppIconModule : Module() {
 
                     SharedObject.classesToKill.add(currentIcon)
                     SharedObject.icon = newIcon
-
-                    return@Function name
+                    result = name
                 }
+
+                // background the app to trigger icon change
+                try {
+                    currentActivity.moveTaskToBack(true)
+                } catch (e: Exception) {
+                    // do nothing
+                }
+
+                return@Function result
             } catch (e: Exception) {
                 return@Function false
             }

--- a/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconModule.kt
+++ b/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconModule.kt
@@ -1,89 +1,67 @@
 package expo.modules.dynamicappicon
 
-import android.app.Activity
-import android.app.Application
 import android.content.Context
-import android.content.pm.PackageManager
-import android.content.ComponentName
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
 class ExpoDynamicAppIconModule : Module() {
-  override fun definition() = ModuleDefinition {
-    Name("ExpoDynamicAppIcon")
 
-    Function("setAppIcon") { name: String? ->
-      try {
-        if (name == null) {
-          // Reset to default icon
-          var currentIcon = if (!SharedObject.icon.isEmpty()) SharedObject.icon else context.packageName + ".MainActivity"
+    override fun definition() = ModuleDefinition {
+        Name("ExpoDynamicAppIcon")
 
-          // Disable the current icon alias if it's set
-          pm.setComponentEnabledSetting(
-            ComponentName(context.packageName, currentIcon),
-            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-            PackageManager.DONT_KILL_APP
-          )
+        Function("setAppIcon") { name: String? ->
+            try {
+                SharedObject.packageName = context.packageName
+                SharedObject.pm = pm
+                SharedObject.shouldChangeIcon = true
 
-          // Enable the default icon alias (MainActivity)
-          pm.setComponentEnabledSetting(
-            ComponentName(context.packageName, context.packageName + ".MainActivity"),
-            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-            PackageManager.DONT_KILL_APP
-          )
+                if (name == null) {
+                    // Resetting to default icon if nothing passed
+                    var currentIcon =
+                            if (!SharedObject.icon.isEmpty()) SharedObject.icon
+                            else context.packageName + ".MainActivity"
 
-          // Reset SharedObject icon to default
-          SharedObject.icon = ""
+                    SharedObject.classesToKill.add(currentIcon)
+                    SharedObject.icon = context.packageName + ".MainActivity"
 
-          return@Function "DEFAULT" // Return a string indicating default icon
-        } else {
-          // Set the new app icon
-          var newIcon: String = context.packageName + ".MainActivity" + name
-          var currentIcon: String = if (!SharedObject.icon.isEmpty()) SharedObject.icon else context.packageName + ".MainActivity"
+                    return@Function "DEFAULT"
+                } else {
 
-          SharedObject.packageName = context.packageName
-          SharedObject.pm = pm
+                    var newIcon: String = context.packageName + ".MainActivity" + name
+                    var currentIcon: String =
+                            if (!SharedObject.icon.isEmpty()) SharedObject.icon
+                            else context.packageName + ".MainActivity"
 
-          // Enable the new icon alias
-          pm.setComponentEnabledSetting(
-            ComponentName(context.packageName, newIcon),
-            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-            PackageManager.DONT_KILL_APP
-          )
+                    if (currentIcon == newIcon) {
+                        return@Function name
+                    }
 
-          // Disable the current icon alias
-          pm.setComponentEnabledSetting(
-            ComponentName(context.packageName, currentIcon),
-            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-            PackageManager.DONT_KILL_APP
-          )
+                    SharedObject.classesToKill.add(currentIcon)
+                    SharedObject.icon = newIcon
 
-          // Update the icon in SharedObject
-          SharedObject.classesToKill.add(currentIcon)
-          SharedObject.icon = newIcon
-
-          return@Function name
+                    return@Function name
+                }
+            } catch (e: Exception) {
+                return@Function false
+            }
         }
-      } catch (e: Exception) {
-        return@Function false
-      }
+
+        Function("getAppIcon") {
+            var componentClass: String = currentActivity.componentName.className
+            var currentIcon: String =
+                    if (!SharedObject.icon.isEmpty()) SharedObject.icon else componentClass
+            var currentIconName: String = currentIcon.split("MainActivity")[1]
+
+            return@Function if (currentIconName.isEmpty()) "DEFAULT" else currentIconName
+        }
     }
 
-    Function("getAppIcon") {
-      var componentClass: String = currentActivity.componentName.className
-      var currentIcon: String = if (!SharedObject.icon.isEmpty()) SharedObject.icon else componentClass
-      var currentIconName: String = currentIcon.split("MainActivity")[1]
+    private val context: Context
+        get() = requireNotNull(appContext.reactContext) { "React Application Context is null" }
 
-      return@Function if (currentIconName.isEmpty()) "DEFAULT" else currentIconName
-    }
-  }
+    private val currentActivity
+        get() = requireNotNull(appContext.activityProvider?.currentActivity)
 
-  private val context: Context
-    get() = requireNotNull(appContext.reactContext) { "React Application Context is null" }
-
-  private val currentActivity
-    get() = requireNotNull(appContext.activityProvider?.currentActivity)
-
-  private val pm
-    get() = requireNotNull(currentActivity.packageManager)
+    private val pm
+        get() = requireNotNull(currentActivity.packageManager)
 }

--- a/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconPackage.kt
+++ b/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconPackage.kt
@@ -5,7 +5,9 @@ import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
 class ExpoDynamicAppIconPackage : Package {
-  override fun createReactActivityLifecycleListeners(activityContext: Context): List<ReactActivityLifecycleListener> {
-    return listOf(ExpoDynamicAppIconReactActivityLifecycleListener())
-  }
+    override fun createReactActivityLifecycleListeners(
+            activityContext: Context
+    ): List<ReactActivityLifecycleListener> {
+        return listOf(ExpoDynamicAppIconReactActivityLifecycleListener())
+    }
 }

--- a/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconReactActivityLifecycleListener.kt
+++ b/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconReactActivityLifecycleListener.kt
@@ -1,38 +1,178 @@
 package expo.modules.dynamicappicon
 
-import android.content.pm.PackageManager
-import android.content.ComponentName
 import android.app.Activity
-import android.os.Bundle
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
-import java.util.ArrayList
-
-
 object SharedObject {
-  var packageName = ""
-  var classesToKill = ArrayList<String>()
-  var icon = ""
-  var pm:PackageManager? = null
+    var packageName: String = ""
+    var classesToKill = ArrayList<String>()
+    var icon: String = ""
+    var pm: PackageManager? = null
+    var shouldChangeIcon: Boolean = false
 }
 
-
 class ExpoDynamicAppIconReactActivityLifecycleListener : ReactActivityLifecycleListener {
-
-  override fun onPause(activity: Activity) {
-    SharedObject.classesToKill.forEach{ cls ->
-      if(SharedObject.pm != null){
-
-        if(cls != SharedObject.icon){
-          SharedObject.pm?.setComponentEnabledSetting(
-            ComponentName(SharedObject.packageName, cls),
-            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-            PackageManager.DONT_KILL_APP
-          )
+    private var currentActivity: Activity? = null
+    private var isBackground = false
+    private val handler = Handler(Looper.getMainLooper())
+    private val backgroundCheckRunnable = Runnable {
+        if (isBackground) {
+            onBackground()
         }
-      }
     }
 
-    SharedObject.classesToKill.clear()
-  }
+    override fun onPause(activity: Activity) {
+        currentActivity = activity
+        isBackground = true
+        // Apply icon change immediately when app goes to background
+        if (SharedObject.shouldChangeIcon) {
+            applyIconChange(activity)
+            // Force close the app after icon change to ensure clean restart
+            handler.postDelayed({
+                forceCloseApp(activity)
+            }, 500) // Small delay to ensure icon change completes
+        }
+    }
+
+    override fun onResume(activity: Activity) {
+        currentActivity = activity
+        isBackground = false
+        handler.removeCallbacks(backgroundCheckRunnable)
+    }
+
+    override fun onDestroy(activity: Activity) {
+        handler.removeCallbacks(backgroundCheckRunnable)
+        if (SharedObject.shouldChangeIcon) {
+            applyIconChange(activity)
+        }
+        if (currentActivity === activity) {
+            currentActivity = null
+        }
+    }
+
+    private fun onBackground() {
+        // This method is no longer used since we apply changes immediately in onPause
+    }
+    
+    private fun forceCloseApp(activity: Activity) {
+        try {
+            // Force close the app process to ensure clean restart
+            activity.finishAffinity()
+            android.os.Process.killProcess(android.os.Process.myPid())
+        } catch (e: Exception) {
+            Log.e("IconChange", "Error force closing app", e)
+        }
+    }
+
+    private fun applyIconChange(activity: Activity) {
+        SharedObject.icon
+            .takeIf { it.isNotEmpty() }
+            ?.let { icon ->
+                val pm = SharedObject.pm ?: return
+                val newComponent = ComponentName(SharedObject.packageName, icon)
+
+                if (!doesComponentExist(newComponent)) {
+                    SharedObject.shouldChangeIcon = false
+                    return
+                }
+
+                try {
+                    // Get all launcher activities and disable all except the new one
+                    val packageInfo =
+                        pm.getPackageInfo(
+                            SharedObject.packageName,
+                            PackageManager.GET_ACTIVITIES or PackageManager.GET_DISABLED_COMPONENTS
+                        )
+
+                    packageInfo.activities?.forEach { activityInfo ->
+                        val componentName =
+                            ComponentName(SharedObject.packageName, activityInfo.name)
+                        val state = pm.getComponentEnabledSetting(componentName)
+
+                        if (
+                            activityInfo.name != icon &&
+                                state != PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+                        ) {
+                            pm.setComponentEnabledSetting(
+                                componentName,
+                                PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                                PackageManager.DONT_KILL_APP
+                            )
+                            Log.i("IconChange", "Disabled component: ${activityInfo.name}")
+                        }
+                    }
+
+                    // Enable the new icon
+                    pm.setComponentEnabledSetting(
+                        newComponent,
+                        PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                        PackageManager.DONT_KILL_APP
+                    )
+                    Log.i("IconChange", "Enabled new icon: $icon")
+                } catch (e: Exception) {
+                    Log.e("IconChange", "Error during icon change", e)
+                } finally {
+                    SharedObject.shouldChangeIcon = false
+                }
+
+                // Ensure at least one component is enabled
+                ensureAtLeastOneComponentEnabled(activity)
+            }
+    }
+
+    private fun ensureAtLeastOneComponentEnabled(context: Context) {
+        val pm = SharedObject.pm ?: return
+        val packageInfo =
+            pm.getPackageInfo(
+                SharedObject.packageName,
+                PackageManager.GET_ACTIVITIES or PackageManager.GET_DISABLED_COMPONENTS
+            )
+
+        val hasEnabledComponent =
+            packageInfo.activities?.any { activityInfo ->
+                val componentName = ComponentName(SharedObject.packageName, activityInfo.name)
+                pm.getComponentEnabledSetting(componentName) ==
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            } ?: false
+
+        if (!hasEnabledComponent) {
+            val mainActivityName = "${SharedObject.packageName}.MainActivity"
+            val mainComponent = ComponentName(SharedObject.packageName, mainActivityName)
+            try {
+                pm.setComponentEnabledSetting(
+                    mainComponent,
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                    PackageManager.DONT_KILL_APP
+                )
+                Log.i("IconChange", "No active component found. Re-enabling $mainActivityName")
+            } catch (e: Exception) {
+                Log.e("IconChange", "Error enabling fallback MainActivity", e)
+            }
+        }
+    }
+
+    /** Check if a component exists in the manifest (including disabled ones). */
+    private fun doesComponentExist(componentName: ComponentName): Boolean {
+        return try {
+            val packageInfo =
+                SharedObject.pm?.getPackageInfo(
+                    SharedObject.packageName,
+                    PackageManager.GET_ACTIVITIES or PackageManager.GET_DISABLED_COMPONENTS
+                )
+
+            val activityExists =
+                packageInfo?.activities?.any { it.name == componentName.className } == true
+
+            activityExists
+        } catch (e: Exception) {
+
+            false
+        }
+    }
 }

--- a/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconView.kt
+++ b/android/src/main/java/expo/modules/dynamicappicon/ExpoDynamicAppIconView.kt
@@ -4,4 +4,5 @@ import android.content.Context
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.views.ExpoView
 
-class ExpoDynamicAppIconView(context: Context, appContext: AppContext) : ExpoView(context, appContext)
+class ExpoDynamicAppIconView(context: Context, appContext: AppContext) :
+        ExpoView(context, appContext)


### PR DESCRIPTION
Inspired by https://github.com/howincodes/expo-dynamic-app-icon, improves the android logic. Instead of trigging the main activity alias change instantly, it:

1. Set a listener to change the app icon when backgrounded and then hard kill the app
2. Triggers the app to background

This is much smoother and is way more consistent